### PR TITLE
Update create.html.j2

### DIFF
--- a/templates/create.html.j2
+++ b/templates/create.html.j2
@@ -11,21 +11,22 @@
 # setup the local directories for the keypairs
 mkdir -p {{ prefix_path }}
 chmod 700 {{ prefix_path }}
-# save the private key to local disk: note that we do not keep this on our servers. if you loosse this, you will need to recreate a new keypair
-cat > {{ prefix_path}}/{{ keys['finger_print'] }} << EOF
+
+# save the private key to local disk and your SSH agent; note that we do not keep this on our servers. if you loosse this, you will need to recreate a new keypair
+cat > {{ prefix_path }}/{{ keys['finger_print'] }} << EOF
 {{ keys['private_key'] }}
 EOF
-chmod 600 {{ prefix_path}}/{{ keys['finger_print'] }}
-# save the public key to local disk
-cat > {{ prefix_path}}/{{ keys['finger_print'] }}.pub << EOF
-{{ keys['public_key'] }}
-EOF
-chmod 600 {{ prefix_path}}//{{ keys['finger_print'] }}.pub
-# add the key to the ssh config file
-cat >> ~/.ssh/config << EOF
+chmod 600 {{ prefix_path }}/{{ keys['finger_print'] }}
+
+# include the s3df config in ssh config
+grep -q "Include {{ prefix_path }}/s3df.conf" ~/.ssh/config || echo "Include {{ prefix_path }}/s3df.conf" >> ~/.ssh/config
+
+# enumerate keys
+keys=$(find {{ prefix_path }} -type f)
+# add s3df ssh dropin config
+cat > {{ prefix_path }}/s3df.conf << EOF
 Host s3df sdfssh002.sdf.slac.stanford.edu s3dflogin-mfa.slac.stanford.edu
-    User {{ username }} # hmm... how to deal with multiple...
-    IdentityFile "{{ prefix_path}}/{{ keys['finger_print'] }}"
+$(for k in $keys; do echo "    IdentityFile {{ prefix_path}}/$k"; done)
 EOF
     </code></pre>
     This keypair ({{ keys['finger_print'] }}) was created_at {{ keys['created_at'] }}, valid_until {{ keys['valid_until']}} and will expires_at {{ keys['expires_at'] }}.

--- a/templates/create.html.j2
+++ b/templates/create.html.j2
@@ -6,6 +6,7 @@
 <body>
     <h1>{{ username }}</h1>
     <p>{{ message }}</p>
+
     <pre><code>
 # do we really want to use the finger_print as the filename? how do keep the local files purged of useless keys?
 # setup the local directories for the keypairs
@@ -26,8 +27,11 @@ keys=$(find {{ prefix_path }} -type f)
 # add s3df ssh dropin config
 cat > {{ prefix_path }}/s3df.conf << EOF
 Host s3df sdfssh002.sdf.slac.stanford.edu s3dflogin-mfa.slac.stanford.edu
-$(for k in $keys; do echo "    IdentityFile {{ prefix_path}}/$k"; done)
+$(for k in $keys; do echo "    IdentityFile {{ prefix_path }}/$k"; done)
 EOF
     </code></pre>
-    This keypair ({{ keys['finger_print'] }}) was created_at {{ keys['created_at'] }}, valid_until {{ keys['valid_until']}} and will expires_at {{ keys['expires_at'] }}.
+
+
+
+    This keypair ({{ keys['finger_print'] }}) was created_at {{ keys['created_at'] }}, valid_until {{ keys['valid_until'] }} and will expires_at {{ keys['expires_at'] }}.
 </html>


### PR DESCRIPTION
Several things happening here:

* We don't actually need to show the user their public key, it just clutters the page. If they want their pubkey for some reason, we can add a note telling them to use `ssh-keygen -y /path/to/privatekey` to get it
* We don't need to worry about multiple SSH configs for multiple users. If someone has multiple users, they're going to be doing `ssh user@host` anyway. Plus matching username to authorized_keys is already accounted for
* An SSH config entry can have multiple `IdentityFile` entries, so we can just grab all the keys the user has in the `s3df` subdirectory and add them all. This is similar to how SSH uses keys normall: it just sends all the fingerprints it has and uses whatever works